### PR TITLE
Up node to v24 or v26 and semver to 0.10.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     name: Run the tests
     strategy:
       matrix:
-         node-version: ['18.x', '20.x']
+         node-version: ['24.x', '26.x']
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,7 @@
 name: Build 🛠️
+permissions:
+  contents: read
+  pull-requests: write
 
 on:
   workflow_dispatch: # can call manually

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,3 +30,31 @@ jobs:
     - run: npm run lint
     - run: npm run build
     - run: npm run test
+
+  comment-success-on-pr:
+    if: success()
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add Success Comment to PR
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: build
+          hide_and_recreate: true
+          hide_classify: "OUTDATED"
+          message: |
+            Lint, build and test passing for commit ${{ github.event.pull_request.head.sha }} 🚀
+
+  comment-failure-on-pr:
+    if: failure()
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add Failure Comment to PR
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: build
+          hide_and_recreate: true
+          hide_classify: "OUTDATED"
+          message: |
+            Lint, build and test FAILING for commit ${{ github.event.pull_request.head.sha }} 💥

--- a/README.md
+++ b/README.md
@@ -23,12 +23,12 @@ A web page showcasing adhere-lib is available at https://bbc.github.io/Adhere/
 ## Setup
 
 ```Shell
-nvm install 20.11.0
-nvm use 20.11.0
+nvm install 24
+nvm use 24
 nvm install-latest-npm
 ```
 
-(latest npm is currently 10.8.1)
+(latest npm is currently 12.0.2)
 
 `cd` to project dir
 
@@ -186,4 +186,4 @@ This is licensed under the Apache 2.0 License.
 
 ## Copyright
 
-Copyright (c) 2021 BBC
+Copyright (c) 2026 BBC

--- a/build-pr.sh
+++ b/build-pr.sh
@@ -3,8 +3,8 @@
 set -e
 
 source /usr/local/nvm/nvm.sh
-nvm install 20.11.0
-nvm use 20.11.0
+nvm install 24
+nvm use 24
 nvm install-latest-npm
 
 # Install & Build

--- a/build.sh
+++ b/build.sh
@@ -3,8 +3,8 @@
 set -e
 
 source /usr/local/nvm/nvm.sh
-nvm install 20.11.0
-nvm use 20.11.0
+nvm install 24
+nvm use 24
 nvm install-latest-npm
 
 # Install & Build

--- a/dist/bin/js/bundle.js
+++ b/dist/bin/js/bundle.js
@@ -231,17 +231,17 @@ eval("{\n\nvar EventEmitter = __webpack_require__(/*! eventemitter3 */ \"./node_
 /******/ });
 /************************************************************************/
 /******/ // The module cache
-/******/ var __webpack_module_cache__ = {};
+/******/ const __webpack_module_cache__ = {};
 /******/ 
 /******/ // The require function
 /******/ function __webpack_require__(moduleId) {
 /******/ 	// Check if module is in cache
-/******/ 	var cachedModule = __webpack_module_cache__[moduleId];
+/******/ 	const cachedModule = __webpack_module_cache__[moduleId];
 /******/ 	if (cachedModule !== undefined) {
 /******/ 		return cachedModule.exports;
 /******/ 	}
 /******/ 	// Create a new module (and put it into the cache)
-/******/ 	var module = __webpack_module_cache__[moduleId] = {
+/******/ 	const module = __webpack_module_cache__[moduleId] = {
 /******/ 		// no module.id needed
 /******/ 		// no module.loaded needed
 /******/ 		exports: {}
@@ -250,7 +250,7 @@ eval("{\n\nvar EventEmitter = __webpack_require__(/*! eventemitter3 */ \"./node_
 /******/ 	// Execute the module function
 /******/ 	if (!(moduleId in __webpack_modules__)) {
 /******/ 		delete __webpack_module_cache__[moduleId];
-/******/ 		var e = new Error("Cannot find module '" + moduleId + "'");
+/******/ 		const e = new Error("Cannot find module '" + moduleId + "'");
 /******/ 		e.code = 'MODULE_NOT_FOUND';
 /******/ 		throw e;
 /******/ 	}
@@ -265,7 +265,7 @@ eval("{\n\nvar EventEmitter = __webpack_require__(/*! eventemitter3 */ \"./node_
 /******/ // startup
 /******/ // Load entry module and return exports
 /******/ // This entry module can't be inlined because the eval devtool is used.
-/******/ var __webpack_exports__ = __webpack_require__("./src/index.es6");
+/******/ let __webpack_exports__ = __webpack_require__("./src/index.es6");
 /******/ const __webpack_exports__Logger = __webpack_exports__.Logger;
 /******/ const __webpack_exports__TextPresenter = __webpack_exports__.TextPresenter;
 /******/ const __webpack_exports__VideoAudioHook = __webpack_exports__.VideoAudioHook;

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
                 "webpack-dev-server": "6.0.0"
             },
             "engines": {
-                "node": ">=18.0"
+                "node": ">=24.0"
             }
         },
         "node_modules/@ava/babel-preset-stage-4": {
@@ -8957,30 +8957,6 @@
             "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/js-yaml": {
-            "version": "5.2.1",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.1.tgz",
-            "integrity": "sha512-zfLtNfQqxVqq3uaTqSkh4x4hZw3KHobGUA0fJUj4wawW8bsQLTVqpHdXSIzidh7o+4lEW36tANuAGdaFx6Zgnw==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/puzrin"
-                },
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/nodeca"
-                }
-            ],
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "argparse": "^2.0.1"
-            },
-            "bin": {
-                "js-yaml": "bin/js-yaml.mjs"
-            }
         },
         "node_modules/jsesc": {
             "version": "3.1.0",
@@ -19779,17 +19755,6 @@
             "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
             "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
             "dev": true
-        },
-        "js-yaml": {
-            "version": "5.2.1",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.1.tgz",
-            "integrity": "sha512-zfLtNfQqxVqq3uaTqSkh4x4hZw3KHobGUA0fJUj4wawW8bsQLTVqpHdXSIzidh7o+4lEW36tANuAGdaFx6Zgnw==",
-            "dev": true,
-            "optional": true,
-            "peer": true,
-            "requires": {
-                "argparse": "^2.0.1"
-            }
         },
         "jsesc": {
             "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "adhere-lib",
-    "version": "0.10.1",
+    "version": "0.10.2",
     "repository": {
         "type": "git",
         "url": "https://github.com/bbc/adhere-lib"
@@ -10,7 +10,7 @@
     "main": "./dist/bin/js/bundle.js",
     "type": "module",
     "engines": {
-        "node": ">=18.0"
+        "node": ">=24.0"
     },
     "resolve": {
         "extensions": [


### PR DESCRIPTION
Preparing for a v0.10.2 release.

GitHub actions were actually running under node 24 anyway, even though the matrix specified now out-of-support versions 18 and 20.